### PR TITLE
SixLabors ImageSharp vulnerability solved

### DIFF
--- a/ComicConverter/ComicConverter.csproj
+++ b/ComicConverter/ComicConverter.csproj
@@ -28,7 +28,7 @@
 	<ItemGroup>
 		<PackageReference Include="PdfSharpCore" Version="1.3.63" />
 		<PackageReference Include="SharpCompress" Version="0.37.2" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.9" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.10" />
 		<PackageReference Include="SkiaSharp" Version="2.88.8" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.8" />
 		<PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.8" />


### PR DESCRIPTION
Out-of-bounds Write in SixLabors ImageSharp solved by updating to 2.1.10